### PR TITLE
Convert string to integer for timeout option

### DIFF
--- a/bin/check-pingdom-credits.rb
+++ b/bin/check-pingdom-credits.rb
@@ -68,7 +68,8 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
 
   option :timeout,
          short: '-t SECS',
-         default: 10
+         default: 10,
+         proc: proc(&:to_i)
 
   def run
     check_sms!


### PR DESCRIPTION
Fixes "CheckPingdomCredits CRITICAL: Check failed to run: can't convert String into time interval" that is thrown when called with timeout option.